### PR TITLE
Fix some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ config :raven,
 Install the Logger backend.
 
 ```elixir
-Logger.add_backend(Raven)
+config :logger, backends: [:console, Raven]
 ```

--- a/lib/raven.ex
+++ b/lib/raven.ex
@@ -210,7 +210,7 @@ defmodule Raven do
       [app, filename, lineno, function] ->
         state = if state.culprit, do: state, else: %{state | culprit: function}
 
-        state = put_in(state.stacktrace.frames, state.stacktrace.frames ++ [%{
+        state = put_in(state.stacktrace.frames, [%{
           filename: filename,
           function: function,
           module: nil,
@@ -222,7 +222,7 @@ defmodule Raven do
           post_context: nil,
           in_app: not app in ["stdlib", "elixir"],
           vars: %{},
-        }])
+        } | state.stacktrace.frames])
 
         transform(t, state)
       :no_match -> transform(t, state)

--- a/lib/raven.ex
+++ b/lib/raven.ex
@@ -12,7 +12,7 @@ defmodule Raven do
 
   Install the Logger backend.
 
-      Logger.add_backend(Raven)
+      config :logger, backends: [:console, Raven]
   """
 
   @type parsed_dsn :: {String.t, String.t, Integer.t}

--- a/test/raven_test.exs
+++ b/test/raven_test.exs
@@ -58,13 +58,13 @@ defmodule RavenTest do
       message: "(RuntimeError) oops",
       platform: "elixir",
       stacktrace: %{
-        frames: [
-          %{filename: "test/raven_test.exs", function: "RavenTest.MyGenServer.handle_call/3", in_app: true, lineno: 25},
-          %{filename: "gen_server.erl", in_app: false}
-          | _
-        ] = frames
+        frames: frames
       }
     } = receive_transform
+    assert [
+      %{filename: "test/raven_test.exs", function: "RavenTest.MyGenServer.handle_call/3", in_app: true, lineno: 25},
+      %{filename: "gen_server.erl", in_app: false}
+    ] = frames |> Enum.reverse |> Enum.take(2)
 
     Enum.each(frames, fn(f) ->
       assert String.valid?(f.filename)
@@ -93,13 +93,14 @@ defmodule RavenTest do
       message: "(RuntimeError) oops",
       platform: "elixir",
       stacktrace: %{
-        frames: [
-          %{filename: "test/raven_test.exs", function: "RavenTest.MyGenEvent.handle_call/2", in_app: true},
-          %{filename: "lib/gen_event.ex", function: "GenEvent.do_handler/3", in_app: false}
-          | _
-        ]
+        frames: frames
       }
     } = receive_transform
+
+    assert [
+      %{filename: "test/raven_test.exs", function: "RavenTest.MyGenEvent.handle_call/2", in_app: true},
+      %{filename: "lib/gen_event.ex", function: "GenEvent.do_handler/3", in_app: false}
+    ] = frames |> Enum.reverse |> Enum.take(2)
   end
 
   test "parses Task crashes" do
@@ -118,9 +119,9 @@ defmodule RavenTest do
       platform: "elixir",
       stacktrace: %{
         frames: [
-          %{filename: "test/raven_test.exs", function: "anonymous fn/0 in RavenTest.task/1", in_app: true},
+          %{filename: "proc_lib.erl", function: ":proc_lib.init_p_do_apply/3", in_app: false},
           %{filename: "lib/task/supervised.ex", function: "Task.Supervised.do_apply/2", in_app: false},
-          %{filename: "proc_lib.erl", function: ":proc_lib.init_p_do_apply/3", in_app: false}
+          %{filename: "test/raven_test.exs", function: "anonymous fn/0 in RavenTest.task/1", in_app: true}
         ]
       }
     } = receive_transform

--- a/test/raven_test.exs
+++ b/test/raven_test.exs
@@ -155,6 +155,19 @@ defmodule RavenTest do
     end
   end
 
+  test "parses undefined function errors" do
+    spawn fn -> Raven.transformm end
+
+    assert %Raven.Event{
+      culprit: nil,
+      level: "error",
+      message: message,
+      platform: "elixir"
+    } = receive_transform
+
+    assert Regex.match? ~r/\(UndefinedFunctionError\)|Error in process/, message
+  end
+
   test "does not crash on unknown error" do
     assert %Raven.Event{} = Raven.transform("unknown error of some kind")
   end


### PR DESCRIPTION
This fixes a few issues I came across trying to get Raven set up in production:

- There was a bug where multi-line messages (like the "Did you mean one of:" message in `UndefinedFunctionError` in recent Elixir) caused a match error against the stack trace regexp. This PR changes it to just skip non-matching lines; ideally there would be some way of combining lines, but that seems tricky to implement.

- The stack traces were being sent in the wrong order (so Sentry was displaying them "oldest first" by default). 

- I wasn't able to get Raven working with `Logger.add_backend` (perhaps because I was putting it in the wrong place, but it's tricky to debug). Using `config` seems to work reliably (and seems to be what the `Logger` docs recommend).